### PR TITLE
Feature/auto

### DIFF
--- a/tests/test_form_fields.py
+++ b/tests/test_form_fields.py
@@ -16,7 +16,7 @@ class TestInput(unittest.TestCase):
         '''.strip()
         result = form_fields.input(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_empty(self):
         context = dict()
@@ -27,7 +27,7 @@ class TestInput(unittest.TestCase):
         '''.strip()
         result = form_fields.input(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_compulsory(self):
         context = dict()
@@ -39,7 +39,7 @@ class TestInput(unittest.TestCase):
         result = wrappers.compulsory(
             form_fields.input(context, 'foo', "Foo:"))
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_data(self):
         context = dict(data=dict(foo='blah'), errors=None)
@@ -50,7 +50,7 @@ class TestInput(unittest.TestCase):
         '''.strip()
         result = form_fields.input(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_errors(self):
         context = dict(data=dict(), errors=dict(foo="Please enter a foo"))
@@ -61,7 +61,7 @@ class TestInput(unittest.TestCase):
         '''.strip()
         result = form_fields.input(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_non_ascii(self):
         context = dict(data=dict(foo=u'blah£'), errors=None)
@@ -72,7 +72,7 @@ class TestInput(unittest.TestCase):
         '''.strip()
         result = form_fields.input(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_non_text(self):
         context = dict(data=dict(foo=1), errors=None)
@@ -83,7 +83,7 @@ class TestInput(unittest.TestCase):
         '''.strip()
         result = form_fields.input(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_with_class(self):
         context = dict(data=None, errors=None)
@@ -94,7 +94,7 @@ class TestInput(unittest.TestCase):
         '''.strip()
         result = form_fields.input(context, 'foo', "Foo:", class_="bar")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_disabled_form(self):
         context = dict(data=None, errors=None, disabled_form=True)
@@ -105,7 +105,7 @@ class TestInput(unittest.TestCase):
         '''.strip()
         result = form_fields.input(context, 'foo', "Foo:", class_="bar")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
         context = dict(data=None, errors=None, disabled_form=False)
         expected = '''
@@ -115,7 +115,7 @@ class TestInput(unittest.TestCase):
         '''.strip()
         result = form_fields.input(context, 'foo', "Foo:", class_="bar")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
 
 class TestSearch(unittest.TestCase):
@@ -128,7 +128,7 @@ class TestSearch(unittest.TestCase):
         '''.strip()
         result = form_fields.search(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_empty(self):
         context = dict()
@@ -139,7 +139,7 @@ class TestSearch(unittest.TestCase):
         '''.strip()
         result = form_fields.search(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_compulsory(self):
         context = dict()
@@ -151,7 +151,7 @@ class TestSearch(unittest.TestCase):
         result = wrappers.compulsory(
             form_fields.search(context, 'foo', "Foo:"))
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_data(self):
         context = dict(data=dict(foo='blah'), errors=None)
@@ -162,7 +162,7 @@ class TestSearch(unittest.TestCase):
         '''.strip()
         result = form_fields.search(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_errors(self):
         context = dict(data=dict(), errors=dict(foo="Please enter a foo"))
@@ -173,7 +173,7 @@ class TestSearch(unittest.TestCase):
         '''.strip()
         result = form_fields.search(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_non_ascii(self):
         context = dict(data=dict(foo=u'blah£'), errors=None)
@@ -184,7 +184,7 @@ class TestSearch(unittest.TestCase):
         '''.strip()
         result = form_fields.search(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_non_text(self):
         context = dict(data=dict(foo=1), errors=None)
@@ -195,7 +195,7 @@ class TestSearch(unittest.TestCase):
         '''.strip()
         result = form_fields.search(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_with_help(self):
         context = dict(data=dict(), errors=dict(foo="Please enter a foo"))
@@ -206,7 +206,7 @@ class TestSearch(unittest.TestCase):
         '''.strip()
         result = form_fields.search(context, 'foo', "Foo:", help='''<a href="#">Help</a>''')
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_disabled_form(self):
         context = dict(data=dict(), errors=None, disabled_form=True)
@@ -217,7 +217,7 @@ class TestSearch(unittest.TestCase):
         '''.strip()
         result = form_fields.search(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
         context = dict(data=dict(), errors=None, disabled_form=False)
         expected = '''
@@ -227,7 +227,7 @@ class TestSearch(unittest.TestCase):
         '''.strip()
         result = form_fields.search(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
 
 class TestCheckbox(unittest.TestCase):
@@ -240,7 +240,7 @@ class TestCheckbox(unittest.TestCase):
 '''.strip()
         result = form_fields.checkbox(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_with_value(self):
         context = dict(data=None, errors=None)
@@ -251,7 +251,7 @@ class TestCheckbox(unittest.TestCase):
 '''.strip()
         result = form_fields.checkbox(context, 'foo', "Foo:", value="wibble")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_empty(self):
         context = dict()
@@ -262,7 +262,7 @@ class TestCheckbox(unittest.TestCase):
         '''.strip()
         result = form_fields.checkbox(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_compulsory(self):
         context = dict()
@@ -274,7 +274,7 @@ class TestCheckbox(unittest.TestCase):
         result = wrappers.compulsory(
             form_fields.checkbox(context, 'foo', "Foo:"))
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_data(self):
         context = dict(data=dict(foo=['blah', 'wangle']), errors=None)
@@ -285,7 +285,7 @@ class TestCheckbox(unittest.TestCase):
         '''.strip()
         result = form_fields.checkbox(context, 'foo', "Foo:", value="blah")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_errors(self):
         context = dict(data=dict(), errors=dict(foo="Please enter a foo"))
@@ -296,7 +296,7 @@ class TestCheckbox(unittest.TestCase):
         '''.strip()
         result = form_fields.checkbox(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_disabled(self):
         context = dict()
@@ -307,7 +307,7 @@ class TestCheckbox(unittest.TestCase):
         '''.strip()
         result = form_fields.checkbox(context, 'foo', "Foo:", disabled=True)
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
         context = dict()
         expected = '''
@@ -317,7 +317,7 @@ class TestCheckbox(unittest.TestCase):
         '''.strip()
         result = form_fields.checkbox(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_disabled_form(self):
         context = dict(disabled_form=True)
@@ -328,7 +328,7 @@ class TestCheckbox(unittest.TestCase):
         '''.strip()
         result = form_fields.checkbox(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
         context = dict(disabled_form=False)
         expected = '''
@@ -338,7 +338,7 @@ class TestCheckbox(unittest.TestCase):
         '''.strip()
         result = form_fields.checkbox(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
 
 class TestPassword(unittest.TestCase):
@@ -351,7 +351,7 @@ class TestPassword(unittest.TestCase):
         '''.strip()
         result = form_fields.password(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_empty(self):
         context = dict()
@@ -362,7 +362,7 @@ class TestPassword(unittest.TestCase):
         '''.strip()
         result = form_fields.password(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_compulsory(self):
         context = dict()
@@ -374,7 +374,7 @@ class TestPassword(unittest.TestCase):
         result = wrappers.compulsory(
             form_fields.password(context, 'foo', "Foo:"))
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_data(self):
         context = dict(data=dict(foo='blah'), errors=None)
@@ -385,7 +385,7 @@ class TestPassword(unittest.TestCase):
         '''.strip()
         result = form_fields.password(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_errors(self):
         context = dict(data=dict(), errors=dict(foo="Please enter a foo"))
@@ -396,7 +396,7 @@ class TestPassword(unittest.TestCase):
         '''.strip()
         result = form_fields.password(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_disabled(self):
         context = dict(data=dict(), errors=None, disabled_form=True)
@@ -407,7 +407,7 @@ class TestPassword(unittest.TestCase):
         '''.strip()
         result = form_fields.password(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
         context = dict(data=dict(), errors=None, disabled_form=False)
         expected = '''
@@ -417,7 +417,7 @@ class TestPassword(unittest.TestCase):
         '''.strip()
         result = form_fields.password(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
 
 class TestSelect(unittest.TestCase):
@@ -434,7 +434,7 @@ class TestSelect(unittest.TestCase):
         '''.strip()
         result = form_fields.select({}, 'foo', "Foo:", options)
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_compulsory(self):
         options = [('bar1', "Bar 1"), ('bar2', "Bar 2"), ('bar3', "Bar 3")]
@@ -450,7 +450,7 @@ class TestSelect(unittest.TestCase):
         result = wrappers.compulsory(
             form_fields.select({}, 'foo', "Foo:", options))
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_data(self):
         options = [('bar1', "Bar 1"), ('bar2', "Bar 2"), ('bar3', "Bar 3")]
@@ -466,7 +466,7 @@ class TestSelect(unittest.TestCase):
         '''.strip()
         result = form_fields.select(context, 'foo', "Foo:", options)
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_errors(self):
         options = [('bar1', "Bar 1"), ('bar2', "Bar 2"), ('bar3', "Bar 3")]
@@ -482,7 +482,7 @@ class TestSelect(unittest.TestCase):
         '''.strip()
         result = form_fields.select(context, 'foo', "Foo:", options)
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_with_values(self):
         options = ["one", "two", "three"]
@@ -498,7 +498,7 @@ class TestSelect(unittest.TestCase):
         '''.strip()
         result = form_fields.select(context, 'foo', "Foo:", options)
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_disabled(self):
         options = [('bar1', "Bar 1"), ('bar2', "Bar 2"), ('bar3', "Bar 3")]
@@ -514,7 +514,7 @@ class TestSelect(unittest.TestCase):
 '''.strip()
         result = form_fields.select(context, 'foo', "Foo:", options, disabled=True)
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
         options = [('bar1', "Bar 1"), ('bar2', "Bar 2"), ('bar3', "Bar 3")]
         context = dict()
@@ -529,7 +529,7 @@ class TestSelect(unittest.TestCase):
 '''.strip()
         result = form_fields.select(context, 'foo', "Foo:", options)
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_disabled_form(self):
         options = [('bar1', "Bar 1"), ('bar2', "Bar 2"), ('bar3', "Bar 3")]
@@ -545,7 +545,7 @@ class TestSelect(unittest.TestCase):
 '''.strip()
         result = form_fields.select(context, 'foo', "Foo:", options)
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
         options = [('bar1', "Bar 1"), ('bar2', "Bar 2"), ('bar3', "Bar 3")]
         context = dict(disabled_form=False)
@@ -560,7 +560,7 @@ class TestSelect(unittest.TestCase):
 '''.strip()
         result = form_fields.select(context, 'foo', "Foo:", options)
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_without_blank_option(self):
         options = [('bar1', "Bar 1"), ('bar2', "Bar 2"), ('bar3', "Bar 3")]
@@ -575,7 +575,7 @@ class TestSelect(unittest.TestCase):
 '''.strip()
         result = form_fields.select(context, 'foo', "Foo:", options, blank_option=False)
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_non_ascii(self):
         options = [(1, "One"), (2, "2"), ('3', u"Bar £")]
@@ -590,7 +590,7 @@ class TestSelect(unittest.TestCase):
 '''.strip()
         result = form_fields.select(context, 'foo', "Foo:", options, blank_option=False)
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
 
 class TestDatePicker(unittest.TestCase):
@@ -603,7 +603,7 @@ class TestDatePicker(unittest.TestCase):
         '''.strip()
         result = form_fields.datepicker(context, 'foo', "Foo:")
         result = result.strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_disabled_form(self):
         context = dict(disabled_form=True)
@@ -614,7 +614,7 @@ class TestDatePicker(unittest.TestCase):
         '''.strip()
         result = form_fields.datepicker(context, 'foo', "Foo:")
         result = result.strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
         context = dict(disabled_form=False)
         expected = '''
@@ -624,7 +624,7 @@ class TestDatePicker(unittest.TestCase):
         '''.strip()
         result = form_fields.datepicker(context, 'foo', "Foo:")
         result = result.strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
 
 class TestTextArea(unittest.TestCase):
@@ -637,7 +637,7 @@ class TestTextArea(unittest.TestCase):
         '''.strip()
         result = form_fields.textarea(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_empty(self):
         context = dict()
@@ -648,7 +648,7 @@ class TestTextArea(unittest.TestCase):
         '''.strip()
         result = form_fields.textarea(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_compulsory(self):
         context = dict()
@@ -660,7 +660,7 @@ class TestTextArea(unittest.TestCase):
         result = wrappers.compulsory(
             form_fields.textarea(context, 'foo', "Foo:"))
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_data(self):
         context = dict(data=dict(foo='Flibble Giblets'), errors=None)
@@ -671,7 +671,7 @@ class TestTextArea(unittest.TestCase):
         '''.strip()
         result = form_fields.textarea(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_non_ascii(self):
         context = dict(data=dict(foo='Flibble Giblets£'), errors=None)
@@ -682,7 +682,7 @@ class TestTextArea(unittest.TestCase):
         '''.strip()
         result = form_fields.textarea(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_errors(self):
         context = dict(data=dict(), errors=dict(foo="Please enter a foo"))
@@ -693,7 +693,7 @@ class TestTextArea(unittest.TestCase):
         '''.strip()
         result = form_fields.textarea(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_disabled_form(self):
         context = dict(disabled_form=True)
@@ -704,7 +704,7 @@ class TestTextArea(unittest.TestCase):
         '''.strip()
         result = form_fields.textarea(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
         context = dict(disabled_form=False)
         expected = '''
@@ -714,7 +714,7 @@ class TestTextArea(unittest.TestCase):
         '''.strip()
         result = form_fields.textarea(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
 
 class TestEditor(unittest.TestCase):
@@ -735,7 +735,7 @@ editor_deselector : "mceNoEditor"
         result = wrappers.compulsory(
             form_fields.tinymce(context, 'foo', "Foo:"))
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_ckeditor(self):
         context = dict(data=None, errors=None)
@@ -758,7 +758,7 @@ CKEDITOR.replace(
                 'toolbar': "'Basic'",
                 'customConfig': "''"})
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_ckeditor_disabled_form(self):
         context = dict(data=None, errors=None, disabled_form=True)
@@ -782,7 +782,7 @@ CKEDITOR.replace(
                 'toolbar': "'Basic'",
                 'customConfig': "''"})
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
         context = dict(data=None, errors=None, disabled_form=False)
         expected = '''
@@ -804,7 +804,7 @@ CKEDITOR.replace(
                 'toolbar': "'Basic'",
                 'customConfig': "''"})
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_wysihtml5(self):
         context = dict(data=None, errors=None)
@@ -833,7 +833,7 @@ new wysihtml5.Editor(
         '''.strip()
         result = form_fields.wysihtml5(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
 
 class TestSubmit(unittest.TestCase):
@@ -842,28 +842,28 @@ class TestSubmit(unittest.TestCase):
         expected = '''<input type="submit" id="submit" value="Submit">'''
         result = form_fields.submit(context)
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_with_labels(self):
         context = dict()
         expected = '''<input type="submit" id="foo" value="Foo!">'''
         result = form_fields.submit(context, 'foo', "Foo!")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_bad_value(self):
         context = dict()
         expected = '''<input type="submit" id="foo" value="Foo&amp;&lt;">'''
         result = form_fields.submit(context, 'foo', "Foo&<")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_with_classes(self):
         context = dict()
         expected = '''<input type="submit" id="submit" value="Submit" class="foo bar">'''
         result = form_fields.submit(context, class_="foo bar")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_disabled_form(self):
         context = dict(disabled_form=True)
@@ -871,14 +871,14 @@ class TestSubmit(unittest.TestCase):
 <input disabled type="submit" id="submit" value="Submit" class="foo bar">'''.strip()
         result = form_fields.submit(context, class_="foo bar")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
         context = dict(disabled_form=False)
         expected = '''
 <input type="submit" id="submit" value="Submit" class="foo bar">'''.strip()
         result = form_fields.submit(context, class_="foo bar")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
 class TestBootstrapFormFields(unittest.TestCase):
     bootstrap_form_fields = form_fields.BootstrapFormFields(
@@ -900,7 +900,7 @@ class TestBootstrapFormFields(unittest.TestCase):
             "span4")
         result = lxml.html.tostring(result, pretty_print=True)
         result = result.strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_input_with_errors(self):
         context = dict(data=None, errors=dict(foo="Please enter a foo"))
@@ -913,7 +913,7 @@ class TestBootstrapFormFields(unittest.TestCase):
         result = self.bootstrap_form_fields.input(context, 'foo', "Foo:")
         result = lxml.html.tostring(result, pretty_print=True)
         result = result.strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_search(self):
         context = dict(data=None, errors=None)
@@ -929,7 +929,7 @@ class TestBootstrapFormFields(unittest.TestCase):
             "search-form image-search-widget span4")
         result = lxml.html.tostring(result, pretty_print=True)
         result = result.strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_checkbox(self):
         context = dict(data=None, errors=None)
@@ -943,7 +943,7 @@ class TestBootstrapFormFields(unittest.TestCase):
             "span2")
         result = lxml.html.tostring(result, pretty_print=True)
         result = result.strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_checkbox_with_value(self):
         context = dict(data=dict(foo=['blah', 'flibble']), errors=None)
@@ -954,7 +954,7 @@ class TestBootstrapFormFields(unittest.TestCase):
         result = self.bootstrap_form_fields.checkbox(context, 'foo', "Foo:", value="flibble")
         result = lxml.html.tostring(result, pretty_print=True)
         result = result.strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_password(self):
         context = dict(data=dict(foo="blah"), errors=None)
@@ -968,7 +968,7 @@ class TestBootstrapFormFields(unittest.TestCase):
             "span3")
         result = lxml.html.tostring(result, pretty_print=True)
         result = result.strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_select(self):
         context = dict(data=None, errors=None)
@@ -987,7 +987,7 @@ class TestBootstrapFormFields(unittest.TestCase):
             "span5")
         result = lxml.html.tostring(result, pretty_print=True)
         result = result.strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_select_disabled(self):
         context = dict(data=None, errors=None)
@@ -1003,7 +1003,7 @@ class TestBootstrapFormFields(unittest.TestCase):
         result = self.bootstrap_form_fields.select({}, 'foo', "Foo:", options, disabled=True)
         result = lxml.html.tostring(result, pretty_print=True)
         result = result.strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_textarea(self):
         context = dict(data=None, errors=None)
@@ -1016,7 +1016,7 @@ class TestBootstrapFormFields(unittest.TestCase):
             "/fieldset",
             "span8")
         result = lxml.html.tostring(result, pretty_print=True)
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_datepicker(self):
         context = dict()
@@ -1032,7 +1032,7 @@ class TestBootstrapFormFields(unittest.TestCase):
             "span5")
         result = lxml.html.tostring(result, pretty_print=True)
         result = result.strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_tinymce(self):
         context = dict(data=None, errors=None)
@@ -1055,7 +1055,7 @@ editor_deselector : "mceNoEditor"
             "/fieldset",
             "span6")
         result = lxml.html.tostring(result, pretty_print=True)
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_ckeditor(self):
         context = dict(data=None, errors=None)
@@ -1079,7 +1079,7 @@ CKEDITOR.replace(
             "/fieldset",
             "span6")
         result = lxml.html.tostring(result, pretty_print=True)
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_wysihtml5(self):
         context = dict(data=None, errors=None)
@@ -1113,11 +1113,11 @@ new wysihtml5.Editor(
             "/fieldset",
             "span6")
         result = lxml.html.tostring(result, pretty_print=True)
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_submit(self):
         context = dict()
         expected = '''<input type="submit" id="foo" value="Foo!" class="btn">'''
         result = self.bootstrap_form_fields.submit(context, 'foo', "Foo!", class_="btn")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)

--- a/tests/test_html_tidy.py
+++ b/tests/test_html_tidy.py
@@ -21,7 +21,7 @@ World!
 The End
 </div>
 '''.strip()
-        assert result == expected
+        self.assertEqual(result, expected)
 
     def test_nbsp(self):
         t = wg.html.Html('''
@@ -35,7 +35,7 @@ The End
 &#160;
 </p>'''.strip()
         result = wg.html_tidy.normalise_html(t).strip()
-        assert result == expected
+        self.assertEqual(result, expected)
 
     def test_empty_tag_with_tail(self):
         t = wg.html.Html('''<p>Hello<img>World</p>''')
@@ -46,7 +46,7 @@ Hello
 World
 </p>'''.strip()
         result = wg.html_tidy.normalise_html(t).strip()
-        assert result == expected
+        self.assertEqual(result, expected)
 
 
 class Test_render_inline_tag(unittest.TestCase):
@@ -58,7 +58,7 @@ class Test_render_inline_tag(unittest.TestCase):
 <br>The End</span>'''
         result = wg.html_tidy._render_inline_tag(wg.html.Html(data)).next().strip()
         expected = '''<span>Hullo <strong>World</strong>! <br>The End</span>'''.strip()
-        assert result == expected
+        self.assertEqual(result, expected)
 
     def test_span_in_para(self):
         data = '''
@@ -71,7 +71,7 @@ World
 </p>'''
         result = wg.html_tidy._render_inline_tag(wg.html.Html(data)).next().strip()
         expected = '''<p><span>Hullo <strong> World</strong>! <br>The End</span></p>'''.strip()
-        assert result == expected
+        self.assertEqual(result, expected)
 
     def test_nbsp(self):
         data = '''
@@ -79,14 +79,14 @@ World
         expected = '''
 <p>&#160;<span>&#160;&#160;&#160;&#160;</span>&#160;</p>'''.strip()
         result = wg.html_tidy._render_inline_tag(wg.html.Html(data)).next().strip()
-        assert result == expected
+        self.assertEqual(result, expected)
 
     def test_comment(self):
         data = '''
 <p><!-- Flibble -->This is not a comment</p>'''
         expected = '''<p><!-- Flibble -->This is not a comment</p>'''
         result = wg.html_tidy._render_inline_tag(wg.html.Html(data)).next().strip()
-        assert result == expected
+        self.assertEqual(result, expected)
 
 class Test_render_block_tag(unittest.TestCase):
     def test_empty_tag(self):
@@ -95,7 +95,7 @@ class Test_render_block_tag(unittest.TestCase):
         expected = '''
 <div></div>
 '''.strip()
-        assert result == expected
+        self.assertEqual(result, expected)
 
     def test_with_tail(self):
         data = '''<div id="foo" class="bar" style="bloop"> Hullo <strong>World!</strong><br>The End</div>'''
@@ -105,7 +105,7 @@ class Test_render_block_tag(unittest.TestCase):
   Hullo <strong>World!</strong><br>The End
 </div>
 '''.strip()
-        assert result == expected
+        self.assertEqual(result, expected)
 
     def test_with_inline_tag(self):
         data = '''
@@ -123,7 +123,7 @@ A Form
   </head>
   <body></body>
 </html>'''.strip()
-        assert result == expected
+        self.assertEqual(result, expected)
 
     def test_nbsp(self):
         data = '''
@@ -133,7 +133,7 @@ A Form
   &#160;<span>&#160;&#160;&#160;&#160;</span>&#160;
 </p>'''.strip()
         result = "\n".join(wg.html_tidy._render_block_tag(wg.html.Html(data))).strip()
-        assert result == expected
+        self.assertEqual(result, expected)
 
     def test_render_empty_tag_with_tail(self):
         data = '''<div>Hello<img>World'''
@@ -142,7 +142,7 @@ A Form
   Hello<img>World
 </div>'''.strip()
         result = "\n".join(wg.html_tidy._render_block_tag(wg.html.Html(data))).strip()
-        assert result == expected
+        self.assertEqual(result, expected)
 
     def test_render_non_empty_block_tag_with_tail(self):
         data = '''<div>Hello<div>Mr</div>Flibble</div>'''
@@ -155,7 +155,7 @@ A Form
   Flibble
 </div>'''.strip()
         result = "\n".join(wg.html_tidy._render_block_tag(wg.html.Html(data))).strip()
-        assert result == expected
+        self.assertEqual(result, expected)
 
     def test_render_empty_block_tag_with_tail(self):
         data = '''<div>Hello<div></div>World</div>'''
@@ -166,7 +166,7 @@ A Form
   World
 </div>'''.strip()
         result = "\n".join(wg.html_tidy._render_block_tag(wg.html.Html(data))).strip()
-        assert result == expected
+        self.assertEqual(result, expected)
 
     def test_image(self):
         data = '''
@@ -177,7 +177,7 @@ A Form
 </p>
 '''.strip()
         result = "\n".join(wg.html_tidy._render_block_tag(wg.html.Html(data))).strip()
-        assert result == expected
+        self.assertEqual(result, expected)
 
     def test_comment(self):
         data = '''
@@ -188,7 +188,7 @@ A Form
   This is not a comment
 </p>'''.strip()
         result = "\n".join(wg.html_tidy._render_block_tag(wg.html.Html(data))).strip()
-        assert result == expected
+        self.assertEqual(result, expected)
 
 class Test_tidy_html(unittest.TestCase):
     def test_fragment(self):
@@ -200,7 +200,7 @@ u'''<div id="foo" class="bar" style="bloop"> Hullo <strong>World!</strong><br>Th
   Hullo <strong>World!</strong><br>The End&#163;
 </div>
 '''.strip()
-        assert result == expected
+        self.assertEqual(result, expected)
 
     def test_document(self):
         t = wg.html.Html(
@@ -246,7 +246,7 @@ Name:
     </form>
   </body>
 </html>'''.strip()
-        assert result == expected
+        self.assertEqual(result, expected)
 
         result = wg.html_tidy.tidy_html(t, with_doctype=False).strip()
 
@@ -268,7 +268,7 @@ Name:
     </form>
   </body>
 </html>'''.strip()
-        assert result == expected
+        self.assertEqual(result, expected)
 
     def test_nbsp(self):
         t = wg.html.Html('''
@@ -278,4 +278,4 @@ Name:
   &#160;<span>&#160;&#160;&#160;&#160;</span>&#160;
 </p>'''.strip()
         result = wg.html_tidy.tidy_html(t).strip()
-        assert result == expected
+        self.assertEqual(result, expected)

--- a/tests/test_jade_mixins.py
+++ b/tests/test_jade_mixins.py
@@ -14,7 +14,7 @@ class TestSelect(unittest.TestCase):
 <option value="bar3">Bar 3</option></select>
         '''.strip()
         result = wiseguy.jade_mixins.select('foo', options).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_with_values(self):
         options = ["one", "two", "three"]
@@ -25,7 +25,7 @@ class TestSelect(unittest.TestCase):
 <option value="three">three</option></select>
         '''.strip()
         result = wiseguy.jade_mixins.select('foo', options).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_with_blank_option(self):
         options = [('bar1', "Bar 1"), ('bar2', "Bar 2"), ('bar3', "Bar 3")]
@@ -37,4 +37,4 @@ class TestSelect(unittest.TestCase):
 <option value="bar3">Bar 3</option></select>
 '''.strip()
         result = wiseguy.jade_mixins.select('foo', options, blank_option=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)

--- a/tests/test_web_utils.py
+++ b/tests/test_web_utils.py
@@ -381,11 +381,11 @@ class TestFormHandler(unittest.TestCase):
 
         result = self.FooForm(MockRequest)
         expected = "This is GET with item_id: None and data: None and errors: None"
-        assert result == expected
+        self.assertEqual(result, expected)
 
         result = self.FooForm(MockRequest, item_id="foo")
         expected = "This is GET with item_id: foo and data: None and errors: None"
-        assert result == expected
+        self.assertEqual(result, expected)
 
     def test_POST(self):
         class MockRequest(object):
@@ -395,7 +395,7 @@ class TestFormHandler(unittest.TestCase):
 
         result = self.FooForm(MockRequest)
         expected = "This is POST with item_id: None and data: {'foo': 'blam'}"
-        assert result == expected
+        self.assertEqual(result, expected)
 
     def test_POST_with_error(self):
         class MockRequest(object):
@@ -405,7 +405,7 @@ class TestFormHandler(unittest.TestCase):
 
         result = self.FooForm(MockRequest)
         expected = "This is GET with item_id: None and data: {'do_raise': True} and errors: {None: 'You told me to raise'}"
-        assert result == expected
+        self.assertEqual(result, expected)
 
     def test_POST_with_nested_data(self):
         class MockRequest(object):
@@ -415,7 +415,7 @@ class TestFormHandler(unittest.TestCase):
 
         result = self.FooForm(MockRequest)
         expected = "This is POST with item_id: None and data: {'flamble': [1, 2, 3], 'flooble': 'flooble'}"
-        assert result == expected
+        self.assertEqual(result, expected)
 
 
 def test_create_require():
@@ -516,8 +516,8 @@ class test_Handler(unittest.TestCase):
 
         foo_handler = FooHandler()
 
-        assert foo_handler.url_route == "/foo"
-        assert foo_handler() == "FOO!"
+        self.assertEqual(foo_handler.url_route, "/foo")
+        self.assertEqual(foo_handler(), "FOO!")
 
     def test_inheritance(self):
         class FooHandler(wu.Handler):
@@ -532,4 +532,4 @@ class test_Handler(unittest.TestCase):
 
         bar_handler = BarHandler()
         assert isinstance(bar_handler.foo, FooHandler)
-        assert bar_handler.foo._parent == bar_handler
+        self.assertEqual(bar_handler.foo._parent, bar_handler)

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -22,7 +22,7 @@ class TestPagination(unittest.TestCase):
         '''.strip()
         result = widgets.prev_li(context, item_url)
         result = lxml.html.tostring(result)
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_prev_li_enabled(self):
         context = dict(offset=1, limit=5)
@@ -31,7 +31,7 @@ class TestPagination(unittest.TestCase):
         '''.strip()
         result = widgets.prev_li(context, item_url)
         result = lxml.html.tostring(result)
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_prev_li_with_kwargs_filter(self):
         context = dict(offset=1, limit=5, DEFAULT_LIMIT=5)
@@ -40,7 +40,7 @@ class TestPagination(unittest.TestCase):
         '''.strip()
         result = widgets.prev_li(context, item_url, self.kwargs_filter)
         result = lxml.html.tostring(result)
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_next_li_disabled(self):
         context = dict(offset=0, limit=5, total=5)
@@ -49,7 +49,7 @@ class TestPagination(unittest.TestCase):
         '''.strip()
         result = widgets.next_li(context, item_url)
         result = lxml.html.tostring(result)
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_next_li_enabled(self):
         context = dict(offset=0, limit=5, total=10)
@@ -58,7 +58,7 @@ class TestPagination(unittest.TestCase):
         '''.strip()
         result = widgets.next_li(context, item_url)
         result = lxml.html.tostring(result)
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_next_li_with_kwargs_filter(self):
         context = dict(offset=0, limit=5, total=10, DEFAULT_LIMIT=5)
@@ -67,7 +67,7 @@ class TestPagination(unittest.TestCase):
         '''.strip()
         result = widgets.next_li(context, item_url, self.kwargs_filter)
         result = lxml.html.tostring(result)
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_simple(self):
         context = dict(offset=0, total=25, limit=5, url=url)
@@ -83,7 +83,7 @@ class TestPagination(unittest.TestCase):
 </ul></div>
 '''.strip()
         result = widgets.pagination(context, item_url).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_ordered(self):
         context = dict(offset=0, total=25, limit=5, order="-flibble", url=url)
@@ -99,7 +99,7 @@ class TestPagination(unittest.TestCase):
 </ul></div>
 '''.strip()
         result = widgets.pagination(context, item_url).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_with_class(self):
         context = dict(offset=0, total=25, limit=5, url=url)
@@ -115,7 +115,7 @@ class TestPagination(unittest.TestCase):
 </ul></div>
 '''.strip()
         result = widgets.pagination(context, item_url, class_="centered").strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_with_kwargs_filter(self):
         context = dict(offset=10, total=25, limit=5, url=url, DEFAULT_LIMIT=5)
@@ -131,7 +131,7 @@ class TestPagination(unittest.TestCase):
 </ul></div>
 '''.strip()
         result = widgets.pagination(context, item_url, self.kwargs_filter).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
 
 class TestPagecounter(unittest.TestCase):
@@ -146,7 +146,7 @@ class TestPagecounter(unittest.TestCase):
             dict(page=4, offset=15, limit=5, start=16, end=20, active=False),
             dict(page=5, offset=20, limit=5, start=21, end=25, active=False),
         ]
-        assert expected == result
+        self.assertEqual(expected, result)
 
 
 class TestBreadcrumbs(unittest.TestCase):
@@ -156,7 +156,7 @@ class TestBreadcrumbs(unittest.TestCase):
         '''.strip()
         pages = [("/", "My Site")]
         result = widgets.breadcrumbs(pages).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_two_levels(self):
         expected = '''
@@ -169,4 +169,4 @@ class TestBreadcrumbs(unittest.TestCase):
         '''.strip()
         pages = [("/", "My Site"), ("/foo", "Foo")]
         result = widgets.breadcrumbs(pages).strip()
-        assert expected == result
+        self.assertEqual(expected, result)

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -49,7 +49,7 @@ class TestWrappers(unittest.TestCase):
             self.bootstrap_form_fields.select({}, 'foo', "Foo:", options),
             5)
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_width_input(self):
         context = dict(data=None, errors=None)
@@ -61,7 +61,7 @@ class TestWrappers(unittest.TestCase):
             self.bootstrap_form_fields.input(context, 'foo', "Foo:"),
             5)
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_compulsory(self):
         context = dict()
@@ -72,7 +72,7 @@ class TestWrappers(unittest.TestCase):
         result = wrappers.compulsory(
             self.bootstrap_form_fields.input(context, 'foo', "Foo:"))
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)
 
     def test_with_class(self):
         context = dict()
@@ -85,4 +85,4 @@ class TestWrappers(unittest.TestCase):
             "//fieldset",
             "flamble")
         result = lxml.html.tostring(result, pretty_print=True).strip()
-        assert expected == result
+        self.assertEqual(expected, result)

--- a/wiseguy/fixture.py
+++ b/wiseguy/fixture.py
@@ -8,6 +8,8 @@ import traceback
 import sqlalchemy as sa
 import sqlalchemy.interfaces
 
+from wiseguy import utils
+
 
 class FixtureTeardownError(Exception):
     """An error that happened in Fixture.__exit__

--- a/wiseguy/form_fields.py
+++ b/wiseguy/form_fields.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from itertools import count
+
 import jinja2 as j2
 import lxml.html
 from lxml.html import builder as html
@@ -8,8 +10,10 @@ from wiseguy import utils
 
 _default = object()
 
+_id_count = count()
 def _gen_element_id(input_type, id):
-    return id
+    return '%s_%s_%04x' % (input_type, id, _id_count)
+
 
 def add_errors(context, element, id):
     "Add an error, if present, to the list of elements"

--- a/wiseguy/html.py
+++ b/wiseguy/html.py
@@ -5,8 +5,6 @@ import copy
 
 import lxml.html, lxml.builder
 
-import jade as Jade
-
 import wiseguy.utils
 import wiseguy.html_tidy
 
@@ -130,6 +128,7 @@ def Html(src):
     return lxml.html.fromstring(src, parser=parser)
 
 def jade(src, context=None):
+    import jade as Jade
     import wiseguy.jade_mixins
     new_context = dict(wiseguy.jade_mixins.mixins)
     if context:


### PR DESCRIPTION
This could probably be split up a bit...

65acf91 adds an element_id parameter which can be used to fix the issue with multiple checkboxes.  Will extend to bootstrap versions if you approve.

0687106 probably shouldn't get accepted as it tries to generate an approximately unique id for each element (using a wrapping counter) and breaks the tests and compatibility.  Just there as an idea.
